### PR TITLE
Fix broken links in amethyst/index.html

### DIFF
--- a/amethyst/index.html
+++ b/amethyst/index.html
@@ -294,9 +294,9 @@ on the top in the vertical orientation.</p>
 <h4 id="binary-space-partitioning-bsp-">Binary Space Partitioning (BSP)</h4>
 <p>This layout does not have a main pane in the way that other layouts do. When adding windows, any given pane can be split evenly into two panes along whatever axis is longer. This is recursive such that pane A can be split in the middle into pane A on the left and pane B on the right; pane B can then be split into pane B on top and pane C on bottom; pane C can then be split into pane C on the left and pane D on the right; and so on.</p>
 <h4 id="custom-beta-">Custom (beta)</h4>
-<p>Custom layouts can be implemented via JavaScript. See <a href="docs/custom-layouts.md">Custom Layouts</a>.</p>
+<p>Custom layouts can be implemented via JavaScript. See <a href="https://github.com/ianyh/Amethyst/tree/development/docs/custom-layouts.md">Custom Layouts</a>.</p>
 <h2 id="configuration">Configuration</h2>
-<p>Amethyst supports configuration via YAML in the home directory. See <a href="docs/configuration-files.md">Configuration Files</a>.</p>
+<p>Amethyst supports configuration via YAML in the home directory. See <a href="https://github.com/ianyh/Amethyst/tree/development/docs/configuration-files.md">Configuration Files</a>.</p>
 <h1 id="contributing">Contributing</h1>
 <p>If you'd like to contribute please branch off of the <code>development</code> branch and open pull requests against it rather than <code>master</code>. Otherwise just try to stick to the general style of the code. There is a setup script to guide you through the process of installing necessary tools and getting dependencies built. To get started run</p>
 <pre><code class="lang-bash">$ ./bin/setup.sh


### PR DESCRIPTION
The links to `Custom Layouts` and `Configuration Files` on https://ianyh.com/amethyst/ are broken as they are relative and lead to https://ianyh.com/amethyst/docs/custom-layouts.md and https://ianyh.com/amethyst/docs/configuration-files.md, respectively. This PR changes them to absolute links pointing to the GitHub source.